### PR TITLE
updating pinot api library version to v0.1.3

### DIFF
--- a/examples/users/main.tf
+++ b/examples/users/main.tf
@@ -7,7 +7,7 @@ terraform {
 }
 
 provider "pinot" {
-  # controller_url = "http://localhost:9000"
+  controller_url = "http://localhost:9000"
 }
 
 resource "pinot_user" "test" {

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,10 @@ module terraform-provider-pinot
 go 1.22
 
 require (
-	github.com/azaurus1/go-pinot-api v0.1.1-0.20240306034329-0b8450520d31
+	github.com/azaurus1/go-pinot-api v0.1.3
 	github.com/hashicorp/terraform-plugin-docs v0.18.0
 	github.com/hashicorp/terraform-plugin-framework v1.6.0
+	github.com/hashicorp/terraform-plugin-log v0.9.0
 	google.golang.org/appengine v1.6.8
 )
 
@@ -35,7 +36,6 @@ require (
 	github.com/hashicorp/terraform-exec v0.20.0 // indirect
 	github.com/hashicorp/terraform-json v0.21.0 // indirect
 	github.com/hashicorp/terraform-plugin-go v0.22.0 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.3 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/azaurus1/go-pinot-api v0.1.1-0.20240306034329-0b8450520d31 h1:57obXV5DpleWQjgo5qrrlIq/QrwywD0F8yVEJrb5NOs=
-github.com/azaurus1/go-pinot-api v0.1.1-0.20240306034329-0b8450520d31/go.mod h1:dx4MyVRh5vanEDFLG6xGeDX5uL82mHvp2OeILo69Sbo=
+github.com/azaurus1/go-pinot-api v0.1.3 h1:kGCdvVhI3xmTu5xiyyXfbblaFUW3R14HKyQb3JyKwso=
+github.com/azaurus1/go-pinot-api v0.1.3/go.mod h1:dx4MyVRh5vanEDFLG6xGeDX5uL82mHvp2OeILo69Sbo=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZlaQsNA=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -137,7 +137,10 @@ func (p *pinotProvider) Configure(ctx context.Context, req provider.ConfigureReq
 		)
 	}
 
-	pinot := goPinotAPI.NewPinotAPIClient(controllerURL, authToken)
+	pinot := goPinotAPI.NewPinotAPIClient(
+		goPinotAPI.ControllerUrl(controllerURL),
+		goPinotAPI.AuthToken(authToken),
+	)
 
 	resp.DataSourceData = pinot
 	resp.ResourceData = pinot


### PR DESCRIPTION
- updates the provider config to reflect changes in the pinot api library
- updates go.mod pinot api library version to v0.1.3