### PR TITLE
support defining a dimension field as multi-valued

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module terraform-provider-pinot
 go 1.22
 
 require (
-	github.com/azaurus1/go-pinot-api v0.2.1
+	github.com/azaurus1/go-pinot-api v0.3.0
 	github.com/hashicorp/terraform-plugin-docs v0.18.0
 	github.com/hashicorp/terraform-plugin-framework v1.7.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/azaurus1/go-pinot-api v0.2.1 h1:1dazyrw2Dw/D7yw93uM/jDha9A5r1lWDZy9QW+rTsbA=
-github.com/azaurus1/go-pinot-api v0.2.1/go.mod h1:Zxi9gp5nAlU95XH1FQlAXLzH/cLGdX6KaisGtVF56t0=
+github.com/azaurus1/go-pinot-api v0.3.0 h1:BHfMN9pvupC13oi9aYRqatfjPfG8ZiHaMzRPn52k9bg=
+github.com/azaurus1/go-pinot-api v0.3.0/go.mod h1:Zxi9gp5nAlU95XH1FQlAXLzH/cLGdX6KaisGtVF56t0=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZlaQsNA=

--- a/internal/provider/table_schema_resource.go
+++ b/internal/provider/table_schema_resource.go
@@ -36,7 +36,7 @@ type dimensionFieldSpec struct {
 	Name             string              `tfsdk:"name"`
 	DataType         string              `tfsdk:"data_type"`
 	NotNull          basetypes.BoolValue `tfsdk:"not_null"`
-	SingleValueField basetypes.BoolValue `tfsdk:"single_value_ield"`
+	SingleValueField basetypes.BoolValue `tfsdk:"single_value_field"`
 }
 
 type dateTimeFieldSpec struct {
@@ -104,6 +104,10 @@ func (t *tableSchemaResource) Schema(_ context.Context, _ resource.SchemaRequest
 						},
 						"not_null": schema.BoolAttribute{
 							Description: "Whether the dimension is not null.",
+							Optional:    true,
+						},
+						"single_value_field": schema.BoolAttribute{
+							Description: "Whether the dimension is a single value field.",
 							Optional:    true,
 						},
 					},
@@ -306,10 +310,6 @@ func (t *tableSchemaResource) Delete(ctx context.Context, req resource.DeleteReq
 	}
 }
 
-func boolPtr(b bool) *bool {
-	return &b
-}
-
 func toDimensionFieldSpecs(fieldSpecs []dimensionFieldSpec) []model.FieldSpec {
 
 	var pinotFieldSpecs []model.FieldSpec
@@ -317,7 +317,7 @@ func toDimensionFieldSpecs(fieldSpecs []dimensionFieldSpec) []model.FieldSpec {
 		pinotFieldSpecs = append(pinotFieldSpecs, model.FieldSpec{
 			Name:     fs.Name,
 			DataType: fs.DataType,
-			NotNull:  boolPtr(fs.NotNull.ValueBool()),
+			NotNull:  fs.NotNull.ValueBoolPointer(),
 		})
 	}
 	return pinotFieldSpecs
@@ -330,7 +330,7 @@ func toMetricFieldSpecs(fieldSpecs []metricFieldSpec) []model.FieldSpec {
 		pinotFieldSpecs = append(pinotFieldSpecs, model.FieldSpec{
 			Name:     fs.Name,
 			DataType: fs.DataType,
-			NotNull:  boolPtr(fs.NotNull.ValueBool()),
+			NotNull:  fs.NotNull.ValueBoolPointer(),
 		})
 	}
 	return pinotFieldSpecs
@@ -344,7 +344,7 @@ func toDateTimeFieldSpecs(fieldSpecs []dateTimeFieldSpec) []model.FieldSpec {
 			DataType:    fs.DataType,
 			Format:      fs.Format,
 			Granularity: fs.Granularity,
-			NotNull:     boolPtr(fs.NotNull.ValueBool()),
+			NotNull:     fs.NotNull.ValueBoolPointer(),
 		})
 	}
 	return pinotFieldSpecs
@@ -357,7 +357,7 @@ func setState(state *tableSchemaResourceModel, schema *model.Schema) {
 		dimensionFieldSpecs[i] = dimensionFieldSpec{
 			Name:     fs.Name,
 			DataType: fs.DataType,
-			NotNull:  basetypes.NewBoolValue(*fs.NotNull),
+			NotNull:  basetypes.NewBoolPointerValue(fs.NotNull),
 		}
 	}
 
@@ -366,7 +366,7 @@ func setState(state *tableSchemaResourceModel, schema *model.Schema) {
 		metricFieldSpecs[i] = metricFieldSpec{
 			Name:     fs.Name,
 			DataType: fs.DataType,
-			NotNull:  basetypes.NewBoolValue(*fs.NotNull),
+			NotNull:  basetypes.NewBoolPointerValue(fs.NotNull),
 		}
 	}
 
@@ -377,7 +377,7 @@ func setState(state *tableSchemaResourceModel, schema *model.Schema) {
 			DataType:    fs.DataType,
 			Format:      fs.Format,
 			Granularity: fs.Granularity,
-			NotNull:     basetypes.NewBoolValue(*fs.NotNull),
+			NotNull:     basetypes.NewBoolPointerValue(fs.NotNull),
 		}
 	}
 

--- a/internal/provider/table_schema_resource.go
+++ b/internal/provider/table_schema_resource.go
@@ -26,10 +26,17 @@ func NewTableSchemaResource() resource.Resource {
 
 }
 
-type fieldSpec struct {
+type metricFieldSpec struct {
 	Name     string              `tfsdk:"name"`
 	DataType string              `tfsdk:"data_type"`
 	NotNull  basetypes.BoolValue `tfsdk:"not_null"`
+}
+
+type dimensionFieldSpec struct {
+	Name             string              `tfsdk:"name"`
+	DataType         string              `tfsdk:"data_type"`
+	NotNull          basetypes.BoolValue `tfsdk:"not_null"`
+	SingleValueField basetypes.BoolValue `tfsdk:"single_value_ield"`
 }
 
 type dateTimeFieldSpec struct {
@@ -41,12 +48,12 @@ type dateTimeFieldSpec struct {
 }
 
 type tableSchemaResourceModel struct {
-	SchemaName                    types.String        `tfsdk:"schema_name"`
-	EnableColumnBasedNullHandling basetypes.BoolValue `tfsdk:"enable_column_based_null_handling"`
-	DimensionFieldSpecs           []fieldSpec         `tfsdk:"dimension_field_specs"`
-	MetricFieldSpecs              []fieldSpec         `tfsdk:"metric_field_specs"`
-	DateTimeFieldSpecs            []dateTimeFieldSpec `tfsdk:"date_time_field_specs"`
-	PrimaryKeyColumns             []string            `tfsdk:"primary_key_columns"`
+	SchemaName                    types.String         `tfsdk:"schema_name"`
+	EnableColumnBasedNullHandling basetypes.BoolValue  `tfsdk:"enable_column_based_null_handling"`
+	DimensionFieldSpecs           []dimensionFieldSpec `tfsdk:"dimension_field_specs"`
+	MetricFieldSpecs              []metricFieldSpec    `tfsdk:"metric_field_specs"`
+	DateTimeFieldSpecs            []dateTimeFieldSpec  `tfsdk:"date_time_field_specs"`
+	PrimaryKeyColumns             []string             `tfsdk:"primary_key_columns"`
 }
 
 func (t *tableSchemaResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
@@ -172,8 +179,8 @@ func (t *tableSchemaResource) Create(ctx context.Context, req resource.CreateReq
 
 	pinotSchema := model.Schema{
 		SchemaName:          plan.SchemaName.ValueString(),
-		DimensionFieldSpecs: toPinotModelFieldSpec(plan.DimensionFieldSpecs),
-		MetricFieldSpecs:    toPinotModelFieldSpec(plan.MetricFieldSpecs),
+		DimensionFieldSpecs: toDimensionFieldSpecs(plan.DimensionFieldSpecs),
+		MetricFieldSpecs:    toMetricFieldSpecs(plan.MetricFieldSpecs),
 		DateTimeFieldSpecs:  toDateTimeFieldSpecs(plan.DateTimeFieldSpecs),
 		PrimaryKeyColumns:   plan.PrimaryKeyColumns,
 	}
@@ -228,8 +235,8 @@ func (t *tableSchemaResource) Update(ctx context.Context, req resource.UpdateReq
 
 	pinotSchema := model.Schema{
 		SchemaName:          plan.SchemaName.ValueString(),
-		DimensionFieldSpecs: toPinotModelFieldSpec(plan.DimensionFieldSpecs),
-		MetricFieldSpecs:    toPinotModelFieldSpec(plan.MetricFieldSpecs),
+		DimensionFieldSpecs: toDimensionFieldSpecs(plan.DimensionFieldSpecs),
+		MetricFieldSpecs:    toMetricFieldSpecs(plan.MetricFieldSpecs),
 		DateTimeFieldSpecs:  toDateTimeFieldSpecs(plan.DateTimeFieldSpecs),
 		PrimaryKeyColumns:   plan.PrimaryKeyColumns,
 	}
@@ -299,14 +306,31 @@ func (t *tableSchemaResource) Delete(ctx context.Context, req resource.DeleteReq
 	}
 }
 
-func toPinotModelFieldSpec(fieldSpecs []fieldSpec) []model.FieldSpec {
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+func toDimensionFieldSpecs(fieldSpecs []dimensionFieldSpec) []model.FieldSpec {
 
 	var pinotFieldSpecs []model.FieldSpec
 	for _, fs := range fieldSpecs {
 		pinotFieldSpecs = append(pinotFieldSpecs, model.FieldSpec{
 			Name:     fs.Name,
 			DataType: fs.DataType,
-			NotNull:  fs.NotNull.ValueBool(),
+			NotNull:  boolPtr(fs.NotNull.ValueBool()),
+		})
+	}
+	return pinotFieldSpecs
+}
+
+func toMetricFieldSpecs(fieldSpecs []metricFieldSpec) []model.FieldSpec {
+
+	var pinotFieldSpecs []model.FieldSpec
+	for _, fs := range fieldSpecs {
+		pinotFieldSpecs = append(pinotFieldSpecs, model.FieldSpec{
+			Name:     fs.Name,
+			DataType: fs.DataType,
+			NotNull:  boolPtr(fs.NotNull.ValueBool()),
 		})
 	}
 	return pinotFieldSpecs
@@ -320,7 +344,7 @@ func toDateTimeFieldSpecs(fieldSpecs []dateTimeFieldSpec) []model.FieldSpec {
 			DataType:    fs.DataType,
 			Format:      fs.Format,
 			Granularity: fs.Granularity,
-			NotNull:     fs.NotNull.ValueBool(),
+			NotNull:     boolPtr(fs.NotNull.ValueBool()),
 		})
 	}
 	return pinotFieldSpecs
@@ -328,21 +352,21 @@ func toDateTimeFieldSpecs(fieldSpecs []dateTimeFieldSpec) []model.FieldSpec {
 
 func setState(state *tableSchemaResourceModel, schema *model.Schema) {
 
-	dimensionFieldSpecs := make([]fieldSpec, len(schema.DimensionFieldSpecs))
+	dimensionFieldSpecs := make([]dimensionFieldSpec, len(schema.DimensionFieldSpecs))
 	for i, fs := range schema.DimensionFieldSpecs {
-		dimensionFieldSpecs[i] = fieldSpec{
+		dimensionFieldSpecs[i] = dimensionFieldSpec{
 			Name:     fs.Name,
 			DataType: fs.DataType,
-			NotNull:  basetypes.NewBoolValue(fs.NotNull),
+			NotNull:  basetypes.NewBoolValue(*fs.NotNull),
 		}
 	}
 
-	metricFieldSpecs := make([]fieldSpec, len(schema.MetricFieldSpecs))
+	metricFieldSpecs := make([]metricFieldSpec, len(schema.MetricFieldSpecs))
 	for i, fs := range schema.MetricFieldSpecs {
-		metricFieldSpecs[i] = fieldSpec{
+		metricFieldSpecs[i] = metricFieldSpec{
 			Name:     fs.Name,
 			DataType: fs.DataType,
-			NotNull:  basetypes.NewBoolValue(fs.NotNull),
+			NotNull:  basetypes.NewBoolValue(*fs.NotNull),
 		}
 	}
 
@@ -353,7 +377,7 @@ func setState(state *tableSchemaResourceModel, schema *model.Schema) {
 			DataType:    fs.DataType,
 			Format:      fs.Format,
 			Granularity: fs.Granularity,
-			NotNull:     basetypes.NewBoolValue(fs.NotNull),
+			NotNull:     basetypes.NewBoolValue(*fs.NotNull),
 		}
 	}
 


### PR DESCRIPTION
In order to address #56, https://github.com/azaurus1/go-pinot-api/pull/126 introduced `singleValueField` schema's property management.

The current PR refers to bumping `go-pinot-api` version to 0.3.0, allowing terraform provider to manage the property in question. Since this is a configuration for dimension fields only, I'm also suggesting the splitting `fieldSpec` in `dimensionFieldSpec` and `metricFieldSpec`.

Other than that, I also needed to refactor `notNull` property usage, given json encoder limitation @gbrlcustodio mentioned in https://github.com/azaurus1/go-pinot-api/pull/126 when it comes to omitted _falsy_ values.

Please be thoughtful about this being my first go at Golang 🥁, so probably this one requires a thorough review before moving on. :sweat_smile: 