### PR TITLE
properly append single_value_field to pinot schema

### DIFF
--- a/internal/provider/table_schema_resource.go
+++ b/internal/provider/table_schema_resource.go
@@ -315,9 +315,10 @@ func toDimensionFieldSpecs(fieldSpecs []dimensionFieldSpec) []model.FieldSpec {
 	var pinotFieldSpecs []model.FieldSpec
 	for _, fs := range fieldSpecs {
 		pinotFieldSpecs = append(pinotFieldSpecs, model.FieldSpec{
-			Name:     fs.Name,
-			DataType: fs.DataType,
-			NotNull:  fs.NotNull.ValueBoolPointer(),
+			Name:             fs.Name,
+			DataType:         fs.DataType,
+			NotNull:          fs.NotNull.ValueBoolPointer(),
+			SingleValueField: fs.SingleValueField.ValueBoolPointer(),
 		})
 	}
 	return pinotFieldSpecs
@@ -355,9 +356,10 @@ func setState(state *tableSchemaResourceModel, schema *model.Schema) {
 	dimensionFieldSpecs := make([]dimensionFieldSpec, len(schema.DimensionFieldSpecs))
 	for i, fs := range schema.DimensionFieldSpecs {
 		dimensionFieldSpecs[i] = dimensionFieldSpec{
-			Name:     fs.Name,
-			DataType: fs.DataType,
-			NotNull:  basetypes.NewBoolPointerValue(fs.NotNull),
+			Name:             fs.Name,
+			DataType:         fs.DataType,
+			NotNull:          basetypes.NewBoolPointerValue(fs.NotNull),
+			SingleValueField: basetypes.NewBoolPointerValue(fs.SingleValueField),
 		}
 	}
 


### PR DESCRIPTION
While bumping pinot provider version to support `singleValueField` management, I noticed that even though the change showed up correctly in the output of `terraform plan`, applying the changes to remote resource wasn't working properly.

```bash
+ resource "pinot_schema" "schema" {
      + dimension_field_specs             = [
          ...
          + {
              ...
              + single_value_field = false
            },
          ...
}
```

After taking a deeper look in the former implementation, I realized that `singleValueField` was added to the structs, but they're not being passed along to schema itself.

The changes in this PR we validated by building the provider locally and performing `terraform apply` against the remote resource. Changes were applied successfully.