### PR TITLE
updated go-pinot-api to 0.4.1, fixed issue with ttls returning float

### DIFF
--- a/examples/tables/main.tf
+++ b/examples/tables/main.tf
@@ -149,6 +149,7 @@ resource "pinot_table" "realtime_table" {
     transform_configs        = local.transform_configs
   })
 
+
   metadata = local.metadata
 
   is_dim_table = local.config_raw["isDimTable"]

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,8 @@ module terraform-provider-pinot
 go 1.22.0
 
 require (
-	github.com/azaurus1/go-pinot-api v0.4.0
+	github.com/azaurus1/go-pinot-api v0.4.1
+	github.com/azaurus1/pinot-testContainer v0.0.0-20240403033323-8a28c4c0636d
 	github.com/hashicorp/terraform-plugin-docs v0.18.0
 	github.com/hashicorp/terraform-plugin-framework v1.7.0
 	github.com/hashicorp/terraform-plugin-go v0.22.1
@@ -24,7 +25,6 @@ require (
 	github.com/agext/levenshtein v1.2.2 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
-	github.com/azaurus1/pinot-testContainer v0.0.0-20240403033323-8a28c4c0636d // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,10 +25,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/azaurus1/go-pinot-api v0.4.0 h1:H1yH1QvLaxxuEvGVPhyJoUz24QUKKj301AuMchrxAfw=
-github.com/azaurus1/go-pinot-api v0.4.0/go.mod h1:Zxi9gp5nAlU95XH1FQlAXLzH/cLGdX6KaisGtVF56t0=
-github.com/azaurus1/pinot-testContainer v0.0.0-20240403031919-9fad6899d753 h1:QQb7sIFUpWJ0NOSFKsKF/psgVXpbQhMT92F299HzWP4=
-github.com/azaurus1/pinot-testContainer v0.0.0-20240403031919-9fad6899d753/go.mod h1:SG7Smj9VxxeB5xy90nHOjAqUVS1D4cWMOwgph2NPQqg=
+github.com/azaurus1/go-pinot-api v0.4.1 h1:4XnOs+0qPceS0ObvIK+HrlQdoWL4xttbwH1ZW8hjJo8=
+github.com/azaurus1/go-pinot-api v0.4.1/go.mod h1:Zxi9gp5nAlU95XH1FQlAXLzH/cLGdX6KaisGtVF56t0=
 github.com/azaurus1/pinot-testContainer v0.0.0-20240403033323-8a28c4c0636d h1:kHkQOHQk8+uHTad97uBhNhg0vEmYPhqeFUqoHxGescU=
 github.com/azaurus1/pinot-testContainer v0.0.0-20240403033323-8a28c4c0636d/go.mod h1:SG7Smj9VxxeB5xy90nHOjAqUVS1D4cWMOwgph2NPQqg=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -2,10 +2,11 @@ package converter
 
 import (
 	"context"
+	"terraform-provider-pinot/internal/models"
+
 	"github.com/azaurus1/go-pinot-api/model"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"terraform-provider-pinot/internal/models"
 )
 
 func SetStateFromTable(ctx context.Context, state *models.TableResourceModel, table *model.Table) diag.Diagnostics {

--- a/internal/converter/override.go
+++ b/internal/converter/override.go
@@ -2,12 +2,13 @@ package converter
 
 import (
 	"context"
-	"github.com/azaurus1/go-pinot-api/model"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"log"
 	"strconv"
 	"terraform-provider-pinot/internal/models"
+
+	"github.com/azaurus1/go-pinot-api/model"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func ToTable(plan *models.TableResourceModel) (*model.Table, diag.Diagnostics) {
@@ -85,7 +86,7 @@ func ToUpsertConfig(ctx context.Context, stateConfig *models.UpsertConfig) (*mod
 		Mode:                    stateConfig.Mode.ValueString(),
 		PartialUpsertStrategies: partialUpsertStrategies,
 		DeleteRecordColumn:      stateConfig.DeletedRecordColumn.ValueString(),
-		DeletedKeysTTL:          int(stateConfig.DeletedKeysTTL.ValueInt64()),
+		DeletedKeysTTL:          float64(stateConfig.DeletedKeysTTL.ValueInt64()),
 		HashFunction:            stateConfig.HashFunction.ValueString(),
 		EnableSnapshot:          stateConfig.EnableSnapshot.ValueBoolPointer(),
 		EnablePreLoad:           stateConfig.EnablePreLoad.ValueBoolPointer(),

--- a/internal/provider/tables_resource.go
+++ b/internal/provider/tables_resource.go
@@ -11,14 +11,16 @@ import (
 	goPinotAPI "github.com/azaurus1/go-pinot-api"
 	"github.com/azaurus1/go-pinot-api/model"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
-	_ resource.Resource              = &tableResource{}
-	_ resource.ResourceWithConfigure = &tableResource{}
+	_ resource.Resource                = &tableResource{}
+	_ resource.ResourceWithConfigure   = &tableResource{}
+	_ resource.ResourceWithImportState = &tableResource{}
 )
 
 func NewTableResource() resource.Resource {
@@ -82,6 +84,10 @@ func (r *tableResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			"metadata":           tf_schema.Metadata(),
 		},
 	}
+}
+
+func (r *tableResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("table_name"), req, resp)
 }
 
 func (r *tableResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {


### PR DESCRIPTION
- updated go-pinot-api to v0.4..1
- fixed issue with ttls returning 0.0
- added import functionality for tables