### PR TITLE
Change Table UpsertConfig MetadataTTL to float64

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module terraform-provider-pinot
 go 1.22.0
 
 require (
-	github.com/azaurus1/go-pinot-api v0.6.4
+	github.com/azaurus1/go-pinot-api v0.6.5
 	github.com/azaurus1/pinot-testContainer v0.0.0-20240404234650-a51c8dc650eb
 	github.com/hashicorp/terraform-plugin-docs v0.19.0
 	github.com/hashicorp/terraform-plugin-framework v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/azaurus1/go-pinot-api v0.6.4 h1:LvtAFMSA09N0K9TTI8NSPJDLlFRxUjnaqS6TGKYV7rY=
-github.com/azaurus1/go-pinot-api v0.6.4/go.mod h1:uSL8T9cQCVP5U0MKBKCYuntMpIqjvZRgGk/epgSAQgw=
+github.com/azaurus1/go-pinot-api v0.6.5 h1:ZqP7C3ZLevrYIV/EGQ9cEXXICUjpzEvWIildqooeEss=
+github.com/azaurus1/go-pinot-api v0.6.5/go.mod h1:uSL8T9cQCVP5U0MKBKCYuntMpIqjvZRgGk/epgSAQgw=
 github.com/azaurus1/pinot-testContainer v0.0.0-20240404234650-a51c8dc650eb h1:yJ1dM1j32OfgXVK8Zb6RiP3arspus5yordrJd/mod0Q=
 github.com/azaurus1/pinot-testContainer v0.0.0-20240404234650-a51c8dc650eb/go.mod h1:SG7Smj9VxxeB5xy90nHOjAqUVS1D4cWMOwgph2NPQqg=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -272,7 +272,7 @@ func convertUpsertConfig(ctx context.Context, table *pinot_api.Table) (*models.U
 	upsertConfig := models.UpsertConfig{
 		Mode:                         types.StringValue(table.UpsertConfig.Mode),
 		PartialUpsertStrategy:        partialUpsertStrategies,
-		MetadataTTL:                  types.Int64Value(table.UpsertConfig.MetadataTTL),
+		MetadataTTL:                  types.Int64Value(int64(table.UpsertConfig.MetadataTTL)),
 		DeletedKeysTTL:               types.Int64Value(int64(table.UpsertConfig.DeletedKeysTTL)),
 		HashFunction:                 types.StringValue(table.UpsertConfig.HashFunction),
 		EnableSnapshot:               types.BoolPointerValue(table.UpsertConfig.EnableSnapshot),

--- a/internal/converter/override.go
+++ b/internal/converter/override.go
@@ -90,7 +90,7 @@ func ToUpsertConfig(ctx context.Context, stateConfig *models.UpsertConfig) (*mod
 		Mode:                         stateConfig.Mode.ValueString(),
 		PartialUpsertStrategies:      partialUpsertStrategies,
 		DeleteRecordColumn:           stateConfig.DeletedRecordColumn.ValueString(),
-		MetadataTTL:                  stateConfig.MetadataTTL.ValueInt64(),
+		MetadataTTL:                  float64(stateConfig.MetadataTTL.ValueInt64()),
 		DeletedKeysTTL:               float64(stateConfig.DeletedKeysTTL.ValueInt64()),
 		HashFunction:                 stateConfig.HashFunction.ValueString(),
 		EnableSnapshot:               stateConfig.EnableSnapshot.ValueBoolPointer(),


### PR DESCRIPTION
This pull request changes the table upsertConfig metadataTTL from int to float64 due to the error mentioned in the following issue:

https://github.com/azaurus1/go-pinot-api/issues/191

Please note that it depends on the PR -> https://github.com/azaurus1/go-pinot-api/pull/190