### PR TITLE
Fixes Nil pointers

### DIFF
--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -24,9 +24,13 @@ func SetStateFromTable(ctx context.Context, state *models.TableResourceModel, ta
 		state.IngestionConfig = convertIngestionConfig(table)
 	}
 
-	state.TierConfigs = convertTierConfigs(table)
-	state.TierConfigs = convertTierConfigs(table)
-	state.Metadata = convertMetadata(table)
+	if state.TierConfigs != nil {
+		state.TierConfigs = convertTierConfigs(table)
+	}
+	
+	if state.Metadata != nil {
+		state.Metadata = convertMetadata(table)
+	}
 
 	tableIndexConfig, resultDiags := convertTableIndexConfig(ctx, table)
 	if resultDiags.HasError() {

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -27,7 +27,7 @@ func SetStateFromTable(ctx context.Context, state *models.TableResourceModel, ta
 	if state.TierConfigs != nil {
 		state.TierConfigs = convertTierConfigs(table)
 	}
-	
+
 	if state.Metadata != nil {
 		state.Metadata = convertMetadata(table)
 	}


### PR DESCRIPTION
# What

Fixes `nil` pointer panics, sometimes the returned state can have `nil` fields, accessing sub fields causes panics

Adds guards to check for `nil` fields
