### PR TITLE
Fixing 'tfsdk' tag of AuthenticationType field in StreamConfig struct

### DIFF
--- a/internal/models/pinot.go
+++ b/internal/models/pinot.go
@@ -150,7 +150,7 @@ type StreamIngestionConfig struct {
 
 type StreamConfig struct {
 	AccessKey                                                        types.String `tfsdk:"access_key"`
-	AuthenticationType                                               types.String `tf_sdk:"authentication_type"`
+	AuthenticationType                                               types.String `tfsdk:"authentication_type"`
 	KeySerializer                                                    types.String `tfsdk:"key_serializer"`
 	MaxRecordsToFetch                                                types.String `tfsdk:"max_records_to_fetch"`
 	RealtimeSegmentCommitTimeoutSeconds                              types.String `tfsdk:"realtime_segment_commit_timeout_seconds"`


### PR DESCRIPTION
Hi @azaurus1,

We missed an underscore in one of the 'tfsdk' tags of the new StreamConfig struct. Apologies for the hassle.

Regards,
Joao