### PR TITLE
fix: make index_type optional for field_config_list

### DIFF
--- a/docs/resources/table.md
+++ b/docs/resources/table.md
@@ -40,11 +40,11 @@ description: |-
 Required:
 
 - `encoding_type` (String) encoding type
-- `index_type` (String) index type
 - `name` (String) name of the field
 
 Optional:
 
+- `index_type` (String) index type
 - `index_types` (List of String) index types
 - `indexes` (Attributes) indexes (see [below for nested schema](#nestedatt--field_config_list--indexes))
 - `timestamp_config` (Attributes) timestamp configuration (see [below for nested schema](#nestedatt--field_config_list--timestamp_config))

--- a/internal/tf_schema/tables_resource.go
+++ b/internal/tf_schema/tables_resource.go
@@ -724,7 +724,7 @@ func FieldConfigList() schema.ListNestedAttribute {
 				},
 				"index_type": schema.StringAttribute{
 					Description: "index type",
-					Required:    true,
+					Optional:    true,
 				},
 				"index_types": schema.ListAttribute{
 					Description: "index types",


### PR DESCRIPTION
https://docs.pinot.apache.org/configuration-reference/table#table-index-config

The field is deprecated.