### PR TITLE
Add missing properties on forward index

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module terraform-provider-pinot
 go 1.22.0
 
 require (
-	github.com/azaurus1/go-pinot-api v0.7.5
+	github.com/azaurus1/go-pinot-api v0.7.6
 	github.com/azaurus1/pinot-testContainer v0.0.0-20240404234650-a51c8dc650eb
 	github.com/hashicorp/terraform-plugin-docs v0.19.0
 	github.com/hashicorp/terraform-plugin-framework v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/azaurus1/go-pinot-api v0.7.5 h1:2o/Hs8kix9vxXNql+0ryRho6h6EFGibpYAboSiJC55o=
-github.com/azaurus1/go-pinot-api v0.7.5/go.mod h1:uSL8T9cQCVP5U0MKBKCYuntMpIqjvZRgGk/epgSAQgw=
+github.com/azaurus1/go-pinot-api v0.7.6 h1:j2cmuTB9M1oHQkeKO9dJtJjQYA2kyEF8gspnK8MSIN8=
+github.com/azaurus1/go-pinot-api v0.7.6/go.mod h1:uSL8T9cQCVP5U0MKBKCYuntMpIqjvZRgGk/epgSAQgw=
 github.com/azaurus1/pinot-testContainer v0.0.0-20240404234650-a51c8dc650eb h1:yJ1dM1j32OfgXVK8Zb6RiP3arspus5yordrJd/mod0Q=
 github.com/azaurus1/pinot-testContainer v0.0.0-20240404234650-a51c8dc650eb/go.mod h1:SG7Smj9VxxeB5xy90nHOjAqUVS1D4cWMOwgph2NPQqg=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -540,6 +540,8 @@ func convertFieldConfigList(table *pinot_api.Table) []*models.FieldConfig {
 					CompressionCodec:      types.StringValue(fieldConfig.Indexes.Forward.CompressionCodec),
 					DeriveNumDocsPerChunk: types.StringValue(fieldConfig.Indexes.Forward.DeriveNumDocsPerChunk),
 					RawIndexWriterVersion: types.StringValue(fieldConfig.Indexes.Forward.RawIndexWriterVersion),
+					TargetDocsPerChunk:    types.StringValue(fieldConfig.Indexes.Forward.TargetDocsPerChunk),
+					TargetMaxChunkSize:    types.StringValue(fieldConfig.Indexes.Forward.TargetMaxChunkSize),
 				}
 			}
 

--- a/internal/converter/override.go
+++ b/internal/converter/override.go
@@ -180,6 +180,8 @@ func ToFieldConfigList(plan *models.TableResourceModel) []model.FieldConfig {
 					CompressionCodec:      fieldConfig.Indexes.Forward.CompressionCodec.ValueString(),
 					DeriveNumDocsPerChunk: fieldConfig.Indexes.Forward.DeriveNumDocsPerChunk.ValueString(),
 					RawIndexWriterVersion: fieldConfig.Indexes.Forward.RawIndexWriterVersion.ValueString(),
+					TargetDocsPerChunk:    fieldConfig.Indexes.Forward.TargetDocsPerChunk.ValueString(),
+					TargetMaxChunkSize:    fieldConfig.Indexes.Forward.TargetMaxChunkSize.ValueString(),
 				}
 			}
 

--- a/internal/models/pinot.go
+++ b/internal/models/pinot.go
@@ -102,6 +102,8 @@ type FieldIndexForward struct {
 	CompressionCodec      types.String `tfsdk:"compressioncodec"`
 	DeriveNumDocsPerChunk types.String `tfsdk:"derivenumdocsperchunk"`
 	RawIndexWriterVersion types.String `tfsdk:"rawindexwriterversion"`
+	TargetDocsPerChunk    types.String `tfsdk:"targetdocsperchunk"`
+	TargetMaxChunkSize    types.String `tfsdk:"targetmaxchunksize"`
 }
 
 type FieldIndexDictionary struct {

--- a/internal/provider/users_data_source_test.go
+++ b/internal/provider/users_data_source_test.go
@@ -22,11 +22,11 @@ func TestAccUsersDataSource(t *testing.T) {
 	// fmt.Println(pinot.URI)
 
 	providerConfig := fmt.Sprintf(`
-provider "pinot" {
-	controller_url = "http://%s"
-	auth_token = "YWRtaW46dmVyeXNlY3JldA"
-}
-`, pinot.URI)
+	provider "pinot" {
+		controller_url = "http://%s"
+		auth_token = "YWRtaW46dmVyeXNlY3JldA"
+	}
+	`, pinot.URI)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/users_resource_test.go
+++ b/internal/provider/users_resource_test.go
@@ -23,28 +23,28 @@ func TestAccUsersResource(t *testing.T) {
 	// fmt.Println(pinot.URI)
 
 	providerConfig := fmt.Sprintf(`
-provider "pinot" {
-	controller_url = "http://%s"
-	auth_token = "YWRtaW46dmVyeXNlY3JldA"
-}
-`, pinot.URI)
+	provider "pinot" {
+		controller_url = "http://%s"
+		auth_token = "YWRtaW46dmVyeXNlY3JldA"
+	}
+	`, pinot.URI)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: providerConfig + `
-resource "pinot_user" "test" {
-	username  = "user"
-	password  = "password"
-	component = "BROKER"
-	role      = "USER"
-				  
-	lifecycle {
-		ignore_changes = [password]
-		}
-}
-`,
+				resource "pinot_user" "test" {
+					username  = "user"
+					password  = "password"
+					component = "BROKER"
+					role      = "USER"
+								
+					lifecycle {
+						ignore_changes = [password]
+						}
+				}
+				`,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("pinot_user.test", "username", "user"),
 					resource.TestCheckResourceAttr("pinot_user.test", "password", "password"),
@@ -61,17 +61,17 @@ resource "pinot_user" "test" {
 			// Update and Read testing
 			{
 				Config: providerConfig + `
-resource "pinot_user" "test" {
-	username  = "user"
-	password  = "password"
-	component = "BROKER"
-	role      = "ADMIN"
+				resource "pinot_user" "test" {
+					username  = "user"
+					password  = "password"
+					component = "BROKER"
+					role      = "ADMIN"
 
-	lifecycle {
-		ignore_changes = [password]
-		}
-}
-`,
+					lifecycle {
+						ignore_changes = [password]
+						}
+				}
+				`,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("pinot_user.test", "username", "user"),
 					// resource.TestCheckResourceAttr("pinot_user.test", "password", "password"), // This is ignored because it returns the salted and hashed password AGAIN

--- a/internal/tf_schema/tables_resource.go
+++ b/internal/tf_schema/tables_resource.go
@@ -790,6 +790,14 @@ func FieldConfigList() schema.ListNestedAttribute {
 									Description: "raw index writer version",
 									Optional:    true,
 								},
+								"targetdocsperchunk": schema.StringAttribute{
+									Description: "The target number of docs per chunk",
+									Optional:    true,
+								},
+								"targetmaxchunksize": schema.StringAttribute{
+									Description: "The target max chunk size",
+									Optional:    true,
+								},
 							},
 						},
 						"dictionary": schema.SingleNestedAttribute{


### PR DESCRIPTION
Hi @azaurus1. 
I would like to add some missing properties on forward indexes targetDocsPerChunk and targetMaxChunkSize by added in go-pinot-api.

Reference:
https://docs.pinot.apache.org/basics/indexing/forward-index#raw-value-forward-index