### PR TITLE
Make Read and schema Update tolerate 404s so partial applies can self-heal

### DIFF
--- a/internal/provider/errors.go
+++ b/internal/provider/errors.go
@@ -1,0 +1,14 @@
+package provider
+
+import "strings"
+
+// isNotFoundError reports whether err represents a 404 response from the Pinot
+// controller. go-pinot-api returns plain string errors (no typed/sentinel
+// errors), so we match on the status code embedded in the message, e.g.
+// `client: request failed with status code: 404, body: {...}`.
+func isNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "status code: 404")
+}

--- a/internal/provider/table_schema_resource.go
+++ b/internal/provider/table_schema_resource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -112,6 +113,8 @@ func (t *tableSchemaResource) Schema(_ context.Context, _ resource.SchemaRequest
 						"not_null": schema.BoolAttribute{
 							Description: "Whether the dimension is not null.",
 							Optional:    true,
+							Computed:    true,
+							Default:     booldefault.StaticBool(false),
 						},
 						"single_value_field": schema.BoolAttribute{
 							Description: "Whether the dimension is a single value field.",
@@ -144,6 +147,8 @@ func (t *tableSchemaResource) Schema(_ context.Context, _ resource.SchemaRequest
 						"not_null": schema.BoolAttribute{
 							Description: "Whether the dimension is not null.",
 							Optional:    true,
+							Computed:    true,
+							Default:     booldefault.StaticBool(false),
 						},
 						"transform_function": schema.StringAttribute{
 							Description: "Transform function for specific field.",
@@ -168,6 +173,8 @@ func (t *tableSchemaResource) Schema(_ context.Context, _ resource.SchemaRequest
 						"not_null": schema.BoolAttribute{
 							Description: "Whether the dimension is not null.",
 							Optional:    true,
+							Computed:    true,
+							Default:     booldefault.StaticBool(false),
 						},
 						"format": schema.StringAttribute{
 							Description: "The format of the date time.",
@@ -404,7 +411,7 @@ func setState(state *tableSchemaResourceModel, schema *model.Schema) {
 		dimensionFieldSpec := dimensionFieldSpec{
 			Name:             fs.Name,
 			DataType:         fs.DataType,
-			NotNull:          basetypes.NewBoolPointerValue(fs.NotNull),
+			NotNull:          basetypes.NewBoolValue(fs.NotNull != nil && *fs.NotNull),
 			SingleValueField: basetypes.NewBoolPointerValue(fs.SingleValueField),
 		}
 		if fs.TransformFunction != "" {
@@ -421,7 +428,7 @@ func setState(state *tableSchemaResourceModel, schema *model.Schema) {
 		metricFieldSpec := metricFieldSpec{
 			Name:     fs.Name,
 			DataType: fs.DataType,
-			NotNull:  basetypes.NewBoolPointerValue(fs.NotNull),
+			NotNull:  basetypes.NewBoolValue(fs.NotNull != nil && *fs.NotNull),
 		}
 		if fs.TransformFunction != "" {
 			metricFieldSpec.TransformFunction = basetypes.NewStringValue(fs.TransformFunction)
@@ -436,7 +443,7 @@ func setState(state *tableSchemaResourceModel, schema *model.Schema) {
 			DataType:    fs.DataType,
 			Format:      fs.Format,
 			Granularity: fs.Granularity,
-			NotNull:     basetypes.NewBoolPointerValue(fs.NotNull),
+			NotNull:     basetypes.NewBoolValue(fs.NotNull != nil && *fs.NotNull),
 		}
 		if fs.TransformFunction != "" {
 			dateTimeFieldSpec.TransformFunction = basetypes.NewStringValue(fs.TransformFunction)

--- a/internal/provider/table_schema_resource.go
+++ b/internal/provider/table_schema_resource.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 
 	pinot "github.com/azaurus1/go-pinot-api"
 	"github.com/azaurus1/go-pinot-api/model"
@@ -240,6 +241,14 @@ func (t *tableSchemaResource) Read(ctx context.Context, req resource.ReadRequest
 
 	tableSchema, err := t.client.GetSchema(state.SchemaName.ValueString())
 	if err != nil {
+		// Schema was deleted out-of-band (e.g. removed directly in Pinot).
+		// Drop it from state so Terraform plans a fresh create instead of
+		// erroring out on every refresh.
+		if isNotFoundError(err) {
+			tflog.Info(ctx, fmt.Sprintf("schema %s not found, removing from state", state.SchemaName.ValueString()))
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Failed to get schema", err.Error())
 		return
 	}
@@ -282,6 +291,15 @@ func (t *tableSchemaResource) Update(ctx context.Context, req resource.UpdateReq
 
 	tableResp, err := t.client.GetTable(plan.SchemaName.ValueString())
 	if err != nil {
+		// No table exists for this schema yet (e.g. the table create failed or
+		// hasn't run). There are no segments to reload, so this is expected
+		// state, not a failure. Only surface non-404 errors.
+		if isNotFoundError(err) {
+			tflog.Info(ctx, "no table matching this schema, skipping segment reload")
+			diagnostics = resp.State.Set(ctx, &plan)
+			resp.Diagnostics.Append(diagnostics...)
+			return
+		}
 		resp.Diagnostics.AddError("Update Failed: Unable to get table", err.Error())
 		return
 	}

--- a/internal/provider/tables_resource.go
+++ b/internal/provider/tables_resource.go
@@ -139,6 +139,14 @@ func (r *tableResource) Read(ctx context.Context, req resource.ReadRequest, resp
 
 	tableResponse, err := r.client.GetTable(state.TableName.ValueString())
 	if err != nil {
+		// Table was deleted out-of-band (e.g. removed directly in Pinot, or a
+		// create that failed after leaving stale state). Drop it from state so
+		// Terraform plans a fresh create instead of erroring on every refresh.
+		if isNotFoundError(err) {
+			tflog.Info(ctx, fmt.Sprintf("table %s not found, removing from state", state.TableName.ValueString()))
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Failed to get table", err.Error())
 		return
 	}


### PR DESCRIPTION
This PR changes how the provider handles `404 Not Found` responses during `Read` and `Update` operations, allowing Terraform to recover from partially applied resources instead of requiring manual cleanup.

If an apply only partially succeeds (e.g. the schema is created but the table creation fails), the provider gets stuck and can't recover on the next apply.

The only way out today is to manually delete the resource from Pinot, run `terraform state rm` (or destroy it with Terraform), and then apply everything again from scratch.

Terraform is expected to converge after a failed apply. Right now it just ends up in a dead-end.

The two issues I keep hitting are:

## 1. `Read` fails on 404 instead of reconciling state

After deleting the schema in Pinot to retry, every subsequent apply failed during the refresh step:

```text
Error: Failed to get schema

client: request failed with status code: 404, body: {"code":404,"error":"Schema not found"}
```

A 404 here should simply mean the resource no longer exists. Instead of returning an error, `Read` should remove it from the Terraform state so the next apply plans a new create.

## 2. Schema `Update` tries to reload segments for a table that doesn't exist

On the retry, Terraform detected a pending schema change, so it executed `Update`. The schema update itself succeeded, but afterwards it tried to reload table segments by calling `GetTable`.

Since the table was never created, that failed with:

```text
Error: Update Failed: Unable to get table

client: request failed with status code: 404, body: {"code":404,"error":"Table metering_production_ai_tokens does not exist"}
```

There's already logic intended to skip the segment reload when no table exists for the schema, but it never gets executed. `GetTable` returns a 404 first, causing the update to fail before reaching that check.

The proposed behavior is to treat `404` as an expected condition instead of a fatal error:

- **`table_schema_resource.go` (`Read`)**: if `GetSchema` returns `404`, call `RemoveResource` so Terraform plans a new create.
- **`tables_resource.go` (`Read`)**: if `GetTable` returns `404`, also call `RemoveResource`.
- **`table_schema_resource.go` (`Update`)**: if `GetTable` returns `404`, skip the segment reload since there's no table to reload.

With these changes (tested in a production real case), a partially applied resource can be recovered with a normal `terraform apply`, without any manual cleanup or state manipulation.