### PR TITLE
Add sasl missing property on stream config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module terraform-provider-pinot
 go 1.22.0
 
 require (
-	github.com/azaurus1/go-pinot-api v0.7.10
+	github.com/azaurus1/go-pinot-api v0.7.11
 	github.com/azaurus1/pinot-testContainer v0.0.0-20240404234650-a51c8dc650eb
 	github.com/hashicorp/terraform-plugin-docs v0.19.0
 	github.com/hashicorp/terraform-plugin-framework v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/azaurus1/go-pinot-api v0.7.10 h1:bk9EOafE1X+0vI3MEUMZN1HwSLv9F0cHklRVcLqQ27M=
-github.com/azaurus1/go-pinot-api v0.7.10/go.mod h1:uSL8T9cQCVP5U0MKBKCYuntMpIqjvZRgGk/epgSAQgw=
+github.com/azaurus1/go-pinot-api v0.7.11 h1:JrNN+SFK2gJo9GSw6S42BX0fzvHdJlHrWh5Y6fxQV1w=
+github.com/azaurus1/go-pinot-api v0.7.11/go.mod h1:uSL8T9cQCVP5U0MKBKCYuntMpIqjvZRgGk/epgSAQgw=
 github.com/azaurus1/pinot-testContainer v0.0.0-20240404234650-a51c8dc650eb h1:yJ1dM1j32OfgXVK8Zb6RiP3arspus5yordrJd/mod0Q=
 github.com/azaurus1/pinot-testContainer v0.0.0-20240404234650-a51c8dc650eb/go.mod h1:SG7Smj9VxxeB5xy90nHOjAqUVS1D4cWMOwgph2NPQqg=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -188,6 +188,7 @@ func convertIngestionConfig(table *pinot_api.Table) *models.IngestionConfig {
 				RealtimeSegmentFlushDesiredSize:                                  types.StringValue(streamConfig.RealtimeSegmentFlushDesiredSize),
 				RealtimeSegmentFlushThresholdSegmentSize:                         types.StringValue(streamConfig.RealtimeSegmentFlushThresholdSegmentSize),
 				Region:                                                           types.StringValue(streamConfig.Region),
+				SaslClientCallbackHandlerClass:                                   types.StringValue(streamConfig.SaslClientCallbackHandlerClass),
 				SaslJaasConfig:                                                   types.StringValue(streamConfig.SaslJaasConfig),
 				SaslMechanism:                                                    types.StringValue(streamConfig.SaslMechanism),
 				SecretKey:                                                        types.StringValue(streamConfig.SecretKey),

--- a/internal/converter/override.go
+++ b/internal/converter/override.go
@@ -537,6 +537,7 @@ func ToIngestionConfig(plan *models.TableResourceModel) *model.TableIngestionCon
 				RealtimeSegmentFlushDesiredSize:                                  streamConfig.RealtimeSegmentFlushDesiredSize.ValueString(),
 				RealtimeSegmentFlushThresholdSegmentSize:                         streamConfig.RealtimeSegmentFlushThresholdSegmentSize.ValueString(),
 				Region:                                                           streamConfig.Region.ValueString(),
+				SaslClientCallbackHandlerClass:                                   streamConfig.SaslClientCallbackHandlerClass.ValueString(),
 				SaslJaasConfig:                                                   streamConfig.SaslJaasConfig.ValueString(),
 				SaslMechanism:                                                    streamConfig.SaslMechanism.ValueString(),
 				SecretKey:                                                        streamConfig.SecretKey.ValueString(),

--- a/internal/models/pinot.go
+++ b/internal/models/pinot.go
@@ -250,6 +250,7 @@ type StreamConfig struct {
 	RealtimeSegmentFlushThresholdSegmentTime                         types.String `tfsdk:"realtime_segment_flush_threshold_segment_time"`
 	RealtimeSegmentServerUploadToDeepStore                           types.String `tfsdk:"realtime_segment_server_upload_to_deep_store"`
 	Region                                                           types.String `tfsdk:"region"`
+	SaslClientCallbackHandlerClass                                   types.String `tfsdk:"sasl_client_callback_handler_class"`
 	SaslJaasConfig                                                   types.String `tfsdk:"sasl_jaas_config"`
 	SaslMechanism                                                    types.String `tfsdk:"sasl_mechanism"`
 	SecretKey                                                        types.String `tfsdk:"secret_key"`

--- a/internal/tf_schema/tables_resource.go
+++ b/internal/tf_schema/tables_resource.go
@@ -374,6 +374,9 @@ func IngestionConfig() schema.SingleNestedAttribute {
 								"region": schema.StringAttribute{
 									Optional: true,
 								},
+								"sasl_client_callback_handler_class": schema.StringAttribute{
+									Optional: true,
+								},
 								"sasl_jaas_config": schema.StringAttribute{
 									Optional: true,
 								},


### PR DESCRIPTION
Hi @azaurus1.
I would like add SASL missing property on stream config implemented on azaurus1/go-pinot-api project.